### PR TITLE
add Compatibility with IE11

### DIFF
--- a/src/shapes/index.js
+++ b/src/shapes/index.js
@@ -14,6 +14,36 @@ export function getRandomShape(excludedShapeTypes = []) {
   return shapesList[randomIndex];
 }
 
+if (typeof Object.assign != 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, 'assign', {
+    value: function assign(target) { // .length of function is 2
+      'use strict';
+      if (target == null) { // TypeError if undefined or null
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      var to = Object(target);
+
+      for (var index = 1; index < arguments.length; index++) {
+        var nextSource = arguments[index];
+
+        if (nextSource != null) { // Skip over if undefined or null
+          for (var nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    },
+    writable: true,
+    configurable: true
+  });
+}
+
 Object.assign(completeShapesList, shapes, deprecatedShapes);
 
 export default completeShapesList;


### PR DESCRIPTION
The Object.assign function doesn't exist in  IE11. I've added the MDN polyfill if the function is not recognized.

This version of your lib is well working in our product on IE11.