### PR TITLE
Added method "image" to get image instead of CanvasPattern

### DIFF
--- a/src/patterns.js
+++ b/src/patterns.js
@@ -23,6 +23,24 @@ export function draw (
   return pattern;
 }
 
+export function image (
+  shapeType = 'square',
+  backgroundColor,
+  patternColor,
+  size
+) {
+  const outerSize = size * 2;
+
+  const image = = new Image(outerSize, outerSize);
+  
+  const Shape = shapes[shapeType];
+  const shape = new Shape(size, backgroundColor, patternColor);
+
+  image.src = shape.drawTile().toDataURL();
+
+  return image;
+}
+
 export function generate(colorList) {
   let firstShapeType;
   let previousShapeType;


### PR DESCRIPTION
Added method "image" to get image instead of CanvasPattern in order to avoid to create a canvas object that it could be useful if the caller has got already a canvas where to create a pattern