### PR TITLE
Add jsDelivr CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This library came about as part of [an issue in Chart.js](https://github.com/cha
 ## Usage
 
     npm install patternomaly
+    
+or include this in your code:
+    
+    <script src="https://cdn.jsdelivr.net/npm/patternomaly@1"></script>
 
 Generate a single canvas pattern
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as an easier and faster option of using the project.